### PR TITLE
Reference to STM32L432 driver implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Related crates
 
 * [stm32f103xx-usb](https://github.com/mvirkkunen/stm32f103xx-usb) - device-driver implementation
   for STM32F103 microcontrollers. Also contains runnable examples.
+* [stm32l43x-usbd](https://github.com/nickray/stm32l43x-usbd) - device-driver implementation
+  for STM32L43x microcontrollers. Also contains runnable examples.
 
 TODO
 ----


### PR DESCRIPTION
FYI: Finally got my port to STM32L432 to run the `serial` example. Cross-referencing https://github.com/dmitrystu/libusb_stm32 was quite helpful. Not sure at all about the naming, as L432, L442, L433, L443 all seem to be the same (apart from LCD/AES additions).