### PR TITLE
Fixing processing order of EP0 (control) transactions

### DIFF
--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -84,6 +84,10 @@ impl<B: UsbBus> ControlPipe<'_, B> {
             },
         };
 
+        // Now that we have properly parsed the setup packet, ensure the end-point is no longer in
+        // a stalled state.
+        self.ep_out.unstall();
+
         /*sprintln!("SETUP {:?} {:?} {:?} req:{} val:{} idx:{} len:{} {:?}",
             req.direction, req.request_type, req.recipient,
             req.request, req.value, req.index, req.length,

--- a/src/device.rs
+++ b/src/device.rs
@@ -169,6 +169,23 @@ impl<B: UsbBus> UsbDevice<'_, B> {
 
                 // Pending events for endpoint 0?
                 if (eps & 1) != 0 {
+                    // Handle EP0-IN conditions first. When both EP0-IN and EP0-OUT have completed,
+                    // it is possible that EP0-OUT is a zero-sized out packet to complete the STATUS
+                    // phase of the control transfer. We have to process EP0-IN first to update our
+                    // internal state properly.
+                    if (ep_in_complete & 1) != 0 {
+                        let completed = self.control.handle_in_complete();
+
+                        if !B::QUIRK_SET_ADDRESS_BEFORE_STATUS {
+                            if completed && self.pending_address != 0 {
+                                self.bus.set_device_address(self.pending_address);
+                                self.pending_address = 0;
+
+                                self.device_state = UsbDeviceState::Addressed;
+                            }
+                        }
+                    }
+
                     let req = if (ep_setup & 1) != 0 {
                         self.control.handle_setup()
                     } else if (ep_out & 1) != 0 {
@@ -184,19 +201,6 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                             => self.control_out(classes, req),
                         _ => (),
                     };
-
-                    if (ep_in_complete & 1) != 0 {
-                        let completed = self.control.handle_in_complete();
-
-                        if !B::QUIRK_SET_ADDRESS_BEFORE_STATUS {
-                            if completed && self.pending_address != 0 {
-                                self.bus.set_device_address(self.pending_address);
-                                self.pending_address = 0;
-
-                                self.device_state = UsbDeviceState::Addressed;
-                            }
-                        }
-                    }
 
                     eps &= !1;
                 }


### PR DESCRIPTION
This PR fixes an issue with the processing order of multiple EP0 events.

Specifically, if both EP0-IN and EP0-OUT events have occurred, we **have** to process EP0-IN first so that we update the `ControlState` properly. Otherwise, we inadvertently process the EP0-OUT status phase as a spurious OUT transfer (instead of the STATUS phase as expected).

This only occurs when both EP0-OUT and EP0-IN transactions occur at the same time, which occurs when polling is completed at a lower-than-continuous rate.

After this fix, this crate can be used in `debug` configuration reliably as well.