### PR TITLE
Add basic IAD support

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -53,6 +53,7 @@ pub(crate) struct Config<'a> {
     pub serial_number: Option<&'a str>,
     pub self_powered: bool,
     pub supports_remote_wakeup: bool,
+    pub composite_with_iads: bool,
     pub max_power: u8,
 }
 

--- a/src/device_builder.rs
+++ b/src/device_builder.rs
@@ -43,6 +43,7 @@ impl<'a, B: UsbBus> UsbDeviceBuilder<'a, B> {
                 serial_number: None,
                 self_powered: false,
                 supports_remote_wakeup: false,
+                composite_with_iads: false,
                 max_power: 50,
             }
         }
@@ -89,6 +90,17 @@ impl<'a, B: UsbBus> UsbDeviceBuilder<'a, B> {
         ///
         /// Default: `false`
         supports_remote_wakeup: bool,
+    }
+
+    /// Configures the device as a composite device with interface association descriptors.
+    pub fn composite_with_iads(mut self) -> Self {
+        // Magic values specified in USB-IF ECN on IADs.
+        self.config.device_class = 0xEF;
+        self.config.device_sub_class = 0x02;
+        self.config.device_protocol = 0x01;
+
+        self.config.composite_with_iads = true;
+        self
     }
 
     /// Sets the manufacturer name string descriptor.


### PR DESCRIPTION
This PR adds minimal support for composite devices with IADs (interface association descriptors). The motivation is to enable out-of-the-box support of composite devices containing CDC-ACM serial ports and other USB functions (such as HID devices) on Windows.

Some references:
https://www.usb.org/sites/default/files/iadclasscode_r10.pdf
https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/usb-interface-association-descriptor
https://www.microchip.com/forums/m189607.aspx
https://community.arm.com/developer/tools-software/tools/f/keil-forum/29075/win7-cdc-hid-only-com-port-works