### PR TITLE
Support devices with SetAddress handled in hardware (Nordic nRF52) 

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -134,6 +134,12 @@ pub trait UsbBus: Sync + Sized {
     ///
     /// The default value for this constant is `false`, which corresponds to the USB 2.0 spec, 9.4.6
     const QUIRK_SET_ADDRESS_BEFORE_STATUS: bool = false;
+
+    /// Indicates that the `UsbDevice` should not send a response to `SetAddress` control transfers.
+    ///
+    /// This defaults to `false`, meaning that `UsbDevice` will handle `SetAddress` transfers. It
+    /// needs to be set to `true` when the device hardware handles `SetAddress`.
+    const INHIBIT_SET_ADDRESS_RESPONSE: bool = false;
 }
 
 struct AllocatorState {

--- a/src/device.rs
+++ b/src/device.rs
@@ -367,6 +367,11 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                     } else {
                         self.pending_address = req.value as u8;
                     }
+
+                    if B::INHIBIT_SET_ADDRESS_RESPONSE {
+                        return;
+                    }
+
                     xfer.accept().ok();
                 },
 


### PR DESCRIPTION
Nordic chips handle address setting entirely in hardware so this has to be skipped.
See https://github.com/nrf-rs/nrf-hal/pull/144 for context.