### PR TITLE
Add imxrt-usbd to the hardware driver crates list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Hardware driver crates
 * [atsamd](https://github.com/atsamd-rs/atsamd) - device-driver implementation for samd21 & samd51 microcontrollers. An example for the
   itsybitsy_m4 board from Adafruit can be found [here](https://github.com/atsamd-rs/atsamd/blob/master/boards/itsybitsy_m4/examples/usb_serial.rs).
 
+* [imxrt-usbd](https://github.com/imxrt-rs/imxrt-usbd) - device-driver implementation for NXP i.MX RT microcontrollers. Examples for
+  i.MX RT boards, like the Teensy 4, are maintained with the driver.
+
 Class crates
 ------------
 


### PR DESCRIPTION
We're working on a usb-device implementation for NXP's i.MX RT
microcontrollers. As of this writing, the driver passes the usb-device
test suite, and it plays well with usbd-serial. Though the peripheral
supports high speed, we're limiting the driver to full speed, since
the usb-device ecosystem doesn't seem high-speed capable.

Not sure if you're still advertising hardware driver crates. But I
figured I'd add a new item, and take the chance to say thanks for
putting this usb-device ecosystem together.