### PR TITLE
Switch from libusb to rusb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/usb-device"
 
 [dev-dependencies]
-libusb = "0.3.0"
+rusb = "0.8.0"
 rand = "0.6.1"
 
 [features]

--- a/tests/test_class_host/device.rs
+++ b/tests/test_class_host/device.rs
@@ -1,32 +1,32 @@
 use std::time::Duration;
-use libusb::*;
+use rusb::*;
 use usb_device::test_class;
 
 pub const TIMEOUT: Duration = Duration::from_secs(1);
 pub const EN_US: u16 = 0x0409;
 
-pub struct DeviceHandles<'a> {
+pub struct DeviceHandles {
     pub device_descriptor: DeviceDescriptor,
     pub config_descriptor: ConfigDescriptor,
-    pub handle: DeviceHandle<'a>,
+    pub handle: DeviceHandle<Context>,
     pub en_us: Language,
 }
 
-impl<'a> ::std::ops::Deref for DeviceHandles<'a> {
-    type Target = DeviceHandle<'a>;
+impl ::std::ops::Deref for DeviceHandles {
+    type Target = DeviceHandle<Context>;
 
-    fn deref(&self) -> &DeviceHandle<'a> {
+    fn deref(&self) -> &DeviceHandle<Context> {
         &self.handle
     }
 }
 
-impl<'a> ::std::ops::DerefMut for DeviceHandles<'a> {
-    fn deref_mut(&mut self) -> &mut DeviceHandle<'a> {
+impl ::std::ops::DerefMut for DeviceHandles {
+    fn deref_mut(&mut self) -> &mut DeviceHandle<Context> {
         &mut self.handle
     }
 }
 
-pub fn open_device(ctx: &Context) -> libusb::Result<DeviceHandles<'_>> {
+pub fn open_device(ctx: &Context) -> rusb::Result<DeviceHandles> {
     for device in ctx.devices()?.iter() {
         let device_descriptor = device.device_descriptor()?;
 
@@ -58,5 +58,5 @@ pub fn open_device(ctx: &Context) -> libusb::Result<DeviceHandles<'_>> {
         }
     }
 
-    Err(libusb::Error::NoDevice)
+    Err(rusb::Error::NoDevice)
 }

--- a/tests/test_class_host/main.rs
+++ b/tests/test_class_host/main.rs
@@ -12,7 +12,7 @@ use std::io::prelude::*;
 use std::thread;
 use std::time::Duration;
 use std::panic;
-use libusb::*;
+use rusb::*;
 use usb_device::device::CONFIGURATION_VALUE;
 use crate::device::open_device;
 use crate::tests::{TestFn, get_tests};
@@ -31,7 +31,7 @@ fn run_tests(tests: &[(&str, TestFn)]) {
     let ctx = Context::new().expect("create libusb context");
 
     // Look for the device for about 5 seconds in case it hasn't finished enumerating yet
-    let mut dev = Err(libusb::Error::NoDevice);
+    let mut dev = Err(rusb::Error::NoDevice);
     for _ in 0..50 {
         dev = open_device(&ctx);
         if dev.is_ok() {

--- a/tests/test_class_host/tests.rs
+++ b/tests/test_class_host/tests.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 use std::fmt::Write;
 use std::time::{Duration, Instant};
-use libusb::*;
+use rusb::*;
 use rand::prelude::*;
 use usb_device::test_class;
 use crate::device::*;
@@ -16,7 +16,7 @@ macro_rules! tests {
             let mut tests: Vec<(&'static str, TestFn)> = Vec::new();
 
             $(
-                fn $name($dev: &mut DeviceHandles<'_>, $out: &mut String) {
+                fn $name($dev: &mut DeviceHandles, $out: &mut String) {
                     $body
                 }
 


### PR DESCRIPTION
It appears that the original libusb is no longer maintained. In anticipation of adding isochronous endpoints to the test class (someday, anyway), this PR upgrades to rusb, which appears to be the most commonly used libusb fork.

The only change was replacing the lifetime parameter of `DeviceHandle`s with a `UsbContext`, which I hardcoded to the `Context` struct.

I tested this by deploying test_class firmware to a imxrt1062 and running the test, all ten cases passed:
```
test_class_host starting
looking for device...

running 10 tests
test control_request ... ok
test control_data ... ok
test control_data_static ... ok
test control_error ... ok
test string_descriptors ... ok
test interface_descriptor ... ok
test bulk_loopback ... ok
test interrupt_loopback ... ok
test bench_bulk_write ... ok
  16 transfers of 65536 bytes in 1.027s -> 8.171Mbit/s
test bench_bulk_read ... ok
  16 transfers of 65536 bytes in 0.970s -> 8.651Mbit/s
0 failed, 10 succeeded

ALL TESTS PASSED!
```
