### PR TITLE
Add write_iter and endpoint_with_additional_data methods

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -79,6 +79,28 @@ impl DescriptorWriter<'_> {
         Ok(())
     }
 
+    /// Writes an arbitrary (usually class-specific) descriptor.
+    pub fn write_iter(&mut self, descriptor_type: u8, descriptor: impl IntoIterator<Item=u8>) -> Result<()> {
+        let start = self.position + 2;
+
+        let mut length = 0;
+        for byte in descriptor {
+            if (self.position + 2 + length) > self.buf.len() || (length + 2) > 255 {
+                return Err(UsbError::BufferOverflow);
+            }
+
+            self.buf[start + length] = byte;
+            length += 1;
+        }
+
+        self.buf[self.position] = (length + 2) as u8;
+        self.buf[self.position + 1] = descriptor_type;
+
+        self.position = start + length;
+
+        Ok(())
+    }
+
     pub(crate) fn device(&mut self, config: &device::Config) -> Result<()> {
         self.write(
             descriptor_type::DEVICE,
@@ -281,6 +303,43 @@ impl DescriptorWriter<'_> {
                 (mps >> 8) as u8,    // wMaxPacketSize
                 endpoint.interval(), // bInterval
             ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Writes an endpoint descriptor with additional data appended.
+    /// Useful for Audio/Midi class endpoint descriptors.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Endpoint previously allocated with
+    ///   [`UsbBusAllocator`](crate::bus::UsbBusAllocator).
+    /// * `additional_data` - Additional data bytes
+    pub fn endpoint_with_additional_data<'e, B: UsbBus, D: EndpointDirection>(
+        &mut self,
+        endpoint: &Endpoint<'e, B, D>,
+        additional_data: impl IntoIterator<Item = u8>,
+    ) -> Result<()> {
+        match self.num_endpoints_mark {
+            Some(mark) => self.buf[mark] += 1,
+            None => return Err(UsbError::InvalidState),
+        };
+
+        let mps = endpoint.max_packet_size();
+
+        self.write_iter(
+            descriptor_type::ENDPOINT,
+            [
+                endpoint.address().into(), // bEndpointAddress
+                endpoint.ep_type() as u8,  // bmAttributes
+                mps as u8,
+                (mps >> 8) as u8,    // wMaxPacketSize
+                endpoint.interval(), // bInterval
+            ]
+            .iter()
+            .cloned()
+            .chain(additional_data),
         )?;
 
         Ok(())


### PR DESCRIPTION
Hi,

USB Audio Class devices (including MIDI devices) extend the endpoint descriptor by two additional bytes, *bRefresh* and *bSynchAddress* (c.f. [the USB MIDI 1.0 spec](https://usb.org/sites/default/files/midi10.pdf) on page 25/26).

Currently, usb-device offers no way to create such an endpoint. I've added such a function and also a more generic way to `write()` into the descriptor: `write_iter` accepts an iterator instead of a slice, allowing for more flexibility using e.g. chained iterators.

I would be happy if this could be merged as it should not cause any incompatibilities.

It would be possible to replace the `endpoint()` method's implementation body by just a call to `endpoint_with_additional_data()` with an empty iterator at a tiny runtime cost.

If you prefer to have this change as well or have anything else to discuss, please let me know!